### PR TITLE
Code can be indented using heredocs

### DIFF
--- a/test/app_test.rb
+++ b/test/app_test.rb
@@ -16,10 +16,10 @@ class AppTest < Minitest::Test
   end
 
   def test_analysis
-    code = <<-CODE
-#!/usr/bin/env ruby
+    code = <<~CODE
+      #!/usr/bin/env ruby
 
-puts "hello"
+      puts "hello"
     CODE
     post "/analyze/ruby", {code: code}.to_json
 


### PR DESCRIPTION
The tilde, "~", before the Heredoc delimiter will provide for tests that are
well formatted for reading, trimming the left hand side indentations
appropriately.